### PR TITLE
Update index.md

### DIFF
--- a/developers/index.md
+++ b/developers/index.md
@@ -52,8 +52,7 @@ components developed by different groups and companies in the community.
 Python
 ------
 
-Python implementation of OpenIGTLink is available at: https://pypi.org/project/pyigtl/
-It supports OpenIGTLinkv3, client and server mode, and the most commonly used message types.
+[pyigtl](https://pypi.org/project/pyigtl/) is a Python implementation of OpenIGTLink. It supports protocol version 3, client and server mode, and the most commonly used message types.
 
 Java
 ----


### PR DESCRIPTION
The previous commit added a link to pyigtl, but did not make it a link. So it only showed up as a link in github preview but not in the rendered github page. This commit explicitly makes the URL a link.